### PR TITLE
Consider sequence position when picking colors.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 *.pyc
 .DS_Store
+*.egg-info

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ def main():
             maintainer_email="gec@threeplusone.com",
             url="https://github.com/WebLogo/weblogo",
 
-            download_url='https://github.com/WebLogo/weblogo/releases' % __version__,
+            download_url='https://github.com/WebLogo/weblogo/releases/%s' % __version__,
             classifiers=[
                 'Development Status :: 5 - Production/Stable',
                 'Intended Audience :: Science/Research',

--- a/test_weblogo.py
+++ b/test_weblogo.py
@@ -199,23 +199,50 @@ class test_seqlogo(unittest.TestCase):
 
 
 class test_colorscheme(unittest.TestCase):
-    def test_colorgroup(self):
-        cr = ColorGroup("ABC", "black", "Because")
-        self.assertEqual(cr.description, "Because")
+    def test_symbol_color(self):
+        sc = SymbolColor("abc", "black", "Because")
+        self.assertEqual(sc.description, "Because")
+        self.assertEqual(sc.symbol_color(0, "A", 0), Color.by_name("black"))
+        self.assertEqual(sc.symbol_color(1, "D", 0), None)
+
+    def test_index_color(self):
+        ic = IndexColor([1,3], "black", "Because")
+        self.assertEqual(ic.description, "Because")
+        self.assertEqual(ic.symbol_color(0, "A", 0), None)
+        self.assertEqual(ic.symbol_color(1, "A", 0), Color.by_name("black"))
+
+    def test_ref_seq_color(self):
+        rc = RefSeqColor("abc", "black", "Because")
+        self.assertEqual(rc.description, "Because")
+
+        self.assertEqual(rc.symbol_color(0, "A", 0), Color.by_name("black"))
+        self.assertEqual(rc.symbol_color(1, "A", 0), None)
+        self.assertEqual(rc.symbol_color(2, "A", 0), None)
+
+        self.assertEqual(rc.symbol_color(0, "B", 0), None)
+        self.assertEqual(rc.symbol_color(1, "B", 0), Color.by_name("black"))
+        self.assertEqual(rc.symbol_color(2, "B", 0), None)
+
+        self.assertEqual(rc.symbol_color(0, "C", 0), None)
+        self.assertEqual(rc.symbol_color(1, "C", 0), None)
+        self.assertEqual(rc.symbol_color(2, "C", 0), Color.by_name("black"))
 
     def test_colorscheme(self):
         cs = ColorScheme([
-            ColorGroup("G", "orange"),
-            ColorGroup("TU", "red"),
-            ColorGroup("C", "blue"),
-            ColorGroup("A", "green")
+            SymbolColor("G", "orange"),
+            SymbolColor("TU", "red"),
+            SymbolColor("C", "blue"),
+            SymbolColor("A", "green")
         ],
                 title="title",
                 description="description",
         )
 
-        self.assertEqual(cs.color('A'), Color.by_name("green"))
-        self.assertEqual(cs.color('X'), cs.default_color)
+        self.assertEqual(cs.symbol_color(1, 'G', 1), Color.by_name("orange"))
+        self.assertEqual(cs.symbol_color(1, 'T', 1), Color.by_name("red"))
+        self.assertEqual(cs.symbol_color(1, 'C', 1), Color.by_name("blue"))
+        self.assertEqual(cs.symbol_color(1, 'A', 1), Color.by_name("green"))
+        self.assertEqual(cs.symbol_color(1, 'X', 1), cs.default_color)
 
 
 class test_color(unittest.TestCase):

--- a/weblogolib/_cgi.py
+++ b/weblogolib/_cgi.py
@@ -49,7 +49,7 @@ from string import Template
 from corebio.utils import *
 from corebio._py3k import StringIO
 from weblogolib.color import *
-from weblogolib.colorscheme import ColorScheme, ColorGroup
+from weblogolib.colorscheme import ColorScheme, SymbolColor
 
 
 cgitb.enable()
@@ -280,7 +280,7 @@ def main(htdocs_directory=None):
 
         if color:
             try:
-                custom.groups.append(weblogolib.ColorGroup(symbols, color, desc))
+                custom.rules.append(SymbolColor(symbols, color, desc))
             except ValueError as e:
                 errors.append(('color%d' % i, "Invalid color: %s" % color))
 

--- a/weblogolib/_cli.py
+++ b/weblogolib/_cli.py
@@ -59,7 +59,7 @@ from . import (LogoOptions, LogoData, LogoFormat,
                read_seq_data)
 from . import (_seq_names, _seq_formats)
 from .color import *
-from .colorscheme import ColorScheme, ColorGroup
+from .colorscheme import ColorScheme, SymbolColor
 
 
 # ====================== Main: Parse Command line =============================
@@ -273,7 +273,7 @@ def _build_logoformat(logodata, opts):
         for color, symbols, desc in opts.colors:
             try:
                 # c = Color.from_string(color)
-                color_scheme.groups.append(ColorGroup(symbols, color, desc))
+                color_scheme.rules.append(SymbolColor(symbols, color, desc))
             except ValueError:
                 raise ValueError(
                         "error: option --color: invalid value: '%s'" % color)

--- a/weblogolib/template.eps
+++ b/weblogolib/template.eps
@@ -76,10 +76,6 @@
 
 /UseCIEColor true def       % Fix for issue 4
 /default_color ${default_color} def 
-/color_dict << 
-${color_dict}
->> def
-
 
 
 % ---- DERIVED PARAMETERS ----
@@ -472,8 +468,9 @@ ${color_dict}
 
 
 % Draw a character whose height is proportional to symbol bits
-/ShowSymbol{ % interval character ShowSymbol
+/ShowSymbol{ % interval color character ShowSymbol
     /char exch def
+    /color exch def
     /interval exch def
     /fraction_width exch def
     
@@ -505,7 +502,7 @@ ${color_dict}
             stack_margin stack_margin rmoveto
             debug { char_height char_width DrawBox } if
             1 fraction_width sub char_width mul 2 div  0 rmoveto
-            fraction_width char_width mul char_height char DrawChar
+            fraction_width char_width mul char_height color char DrawChar
         grestore
         
     } if
@@ -515,6 +512,7 @@ ${color_dict}
 
 /DrawChar { % <width> <height> <char> ShowChar
     /tc exch def    % The character
+    /color exch def % The color of the character
     /ysize exch def % the y size of the character
     /xsize exch def % the x size of the character
     /xmulfactor 1 def 
@@ -522,7 +520,7 @@ ${color_dict}
     
     gsave
         SetLogoFont    
-        tc SetColor
+        color aload pop setrgbcolor
 
         % IReplacementHack
         % Deal with the lack of bars on the letter 'I' in Arial and Helvetica
@@ -573,16 +571,6 @@ ${color_dict}
 
     grestore
 } bind def
-
-/SetColor{ % <char> SetColor
-  dup color_dict exch known {
-    color_dict exch get aload pop setrgbcolor
-  } {
-    pop
-    default_color aload pop setrgbcolor
-  } ifelse 
-} bind def
-
 
 /DrawErrorbar{ % interval_down interval_up DrawErrorbar
     
@@ -641,15 +629,14 @@ ${color_dict}
 %StartLogo
 %    StartLine
 %        (1) StartStack
-%            1.2 (C) ShowSymbol
-%            2.2 (I) ShowSymbol
+%            1.2 [0 0 0] (C) ShowSymbol
+%            2.2 [0 0 0] (I) ShowSymbol
 %            0.5 0.5 DrawErrorbar
 %        EndStack
 %        (2) StartStack
-%            0.5 (I) ShowSymbol
-%            0.9 (L) ShowSymbol
-%            1.0 (G) ShowSymbol
-%            
+%            0.5 [0 0 0] (I) ShowSymbol
+%            0.9 [0 0 0] (L) ShowSymbol
+%            1.0 [0 0 0] (G) ShowSymbol
 %            0.5 0.5 DrawErrorbar        
 %        EndStack
 %        (234) StartStack


### PR DESCRIPTION
This commit was motivated by the desire to color the "wildtype" symbol
in each stack differently, so I could easily see whether or not each
position was mutated.

To do this, I had to generalize the color scheme framework a bit.  Color
schemes are now collections of color rules, which are objects that can
return a color given a sequence index, a symbol, and the ranked order of
that symbol.  I then turned ColorGroup into the SymbolColor rule and
added IndexColor and RefSeqColor rules.

I also had to generalize the *.eps template to support the more flexible
color schemes.  I added a color argument to ShowSymbol and used the
color scheme to generate this argument for each symbol.  Then I removed
color_dict and SetColor, which were both no longer necessary.  The new
*.eps template is actually simpler and more powerful than the old one.