### PR TITLE
change into the examples directory before building examples

### DIFF
--- a/weblogolib/htdocs/examples/build_examples.sh
+++ b/weblogolib/htdocs/examples/build_examples.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+cd "$(dirname "${BASH_SOURCE[0]}")"
+
 echo -n '.'
 ../../../weblogo --format PNG --size large \
     -i -5 -l 1 -u 20 \


### PR DESCRIPTION
This allows the user to run the build_examples.sh script from anywhere on the system.