### PR TITLE
Generalized the TRANSFAC parser to permit other ignored fields and non-alphabetic characters

### DIFF
--- a/corebio/matrix.py
+++ b/corebio/matrix.py
@@ -446,8 +446,16 @@ class Motif(AlphabeticArray):
         if header[0] == 'PO' or header[0] == 'P0':
             header.pop(0)
 
-        position_header = True if all([isint(h) for h in header]) else False
-        alphabet_header = True if position_header is False else False
+        position_header = True
+
+        for h in header:
+            if not ischar(h):
+                raise ValueError("Expected a single character per header "
+                                 "item, but got \"{}\" as one item".format(h))
+            if not isint(h):
+                position_header = False
+
+        alphabet_header = False if position_header else True
 
         # Check row headers
         if alphabet_header:

--- a/corebio/matrix.py
+++ b/corebio/matrix.py
@@ -446,19 +446,8 @@ class Motif(AlphabeticArray):
         if header[0] == 'PO' or header[0] == 'P0':
             header.pop(0)
 
-        position_header = True
-        alphabet_header = True
-        for h in header:
-            if not isint(h):
-                position_header = False
-            if not str.isalpha(h):
-                alphabet_header = False
-
-        if not position_header and not alphabet_header:
-            raise ValueError("Can't parse header: {}".format(str(header)))
-
-        if position_header and alphabet_header:
-            raise ValueError("Can't parse header")
+        position_header = True if all([isint(h) for h in header]) else False
+        alphabet_header = True if position_header is False else False
 
         # Check row headers
         if alphabet_header:
@@ -477,7 +466,7 @@ class Motif(AlphabeticArray):
                 a.append(r.pop(0))
             defacto_alphabet = ''.join(a)
 
-            # Check defacto_alphabet
+        # Check defacto_alphabet
         defacto_alphabet = Alphabet(defacto_alphabet)
 
         if alphabet:


### PR DESCRIPTION
Improved TRANSFAC PWM parsing:

- Extended to permit the use of non-alphabetic symbols, like numerals, within motifs (such as `m`/**`1`**).
- Refactored to allow [other fields](http://gene-regulation.com/pub/databases/transfac/doc/matrix1SM.html), such as the common case of TRANSFAC motifs being prefaced by an Accession no. (the `AC` field) or other metadata.
- Replaced previous tests for position- or alphabetic-only (header field) input with a check for character input, maintaining matrix transposition upon the use of solely positions in the header.
- Conducted overall refactoring of associated code, including converting `read_transfac` to a class method, as suggested, and using a class constant to store delimiters.