### PR TITLE
Allowed TRANSFAC PWMs containing any subset of a provided alphabet to…

### DIFF
--- a/corebio/matrix.py
+++ b/corebio/matrix.py
@@ -478,9 +478,10 @@ class Motif(AlphabeticArray):
         defacto_alphabet = Alphabet(defacto_alphabet)
 
         if alphabet:
-            if not defacto_alphabet.alphabetic(alphabet):
-                raise ValueError("Incompatible alphabets: {} , {} (defacto)".
-                                 format(alphabet, defacto_alphabet))
+            if not Alphabet(alphabet).alphabetic(defacto_alphabet):
+                raise ValueError("The alphabet used within the PWM "
+                                 "({}) must be a subset of that provided "
+                                 "({})".format(defacto_alphabet, alphabet))
         else:
             alphabets = (unambiguous_rna_alphabet,
                          unambiguous_dna_alphabet,
@@ -509,4 +510,4 @@ class Motif(AlphabeticArray):
         if position_header:
             matrix.transpose()
 
-        return Motif(defacto_alphabet, matrix).reindex(alphabet)
+        return Motif(defacto_alphabet, matrix)

--- a/corebio/seq.py
+++ b/corebio/seq.py
@@ -3,7 +3,7 @@
 #  This software is distributed under the MIT Open Source License.
 #  <http://www.opensource.org/licenses/mit-license.html>
 #
-#  Permission is hereby granted, free of charge, to any person obtaining a 
+#  Permission is hereby granted, free of charge, to any person obtaining a
 #  copy of this software and associated documentation files (the "Software"),
 #  to deal in the Software without restriction, including without limitation
 #  the rights to use, copy, modify, merge, publish, distribute, sublicense,
@@ -13,20 +13,19 @@
 #  The above copyright notice and this permission notice shall be included
 #  in all copies or substantial portions of the Software.
 #
-#  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR 
-#  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
+#  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+#  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 #  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-#  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER 
-#  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-#  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN 
-#  THE SOFTWARE.
+#  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+#  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+#  FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+#  IN THE SOFTWARE.
 #
-
 
 
 """ Alphabetic sequences and associated tools and data.
 
-Seq is a subclass of a python string with additional annotation and an alphabet.
+Seq is a subclass of a python string with additional annotation and alphabet.
 The characters in string must be contained in the alphabet. Various standard
 alphabets are provided.
 
@@ -35,24 +34,24 @@ Classes :
     Alphabet    -- A subset of non-null ascii characters
     Seq         -- An alphabetic string
     SeqList     -- A collection of Seq's
-  
-Alphabets :    
+
+Alphabets :
     o generic_alphabet  -- A generic alphabet. Any printable ASCII character.
-    o protein_alphabet -- IUCAP/IUB Amino Acid one letter codes. 
+    o protein_alphabet -- IUCAP/IUB Amino Acid one letter codes.
     o nucleic_alphabet -- IUPAC/IUB Nucleic Acid codes 'ACGTURYSWKMBDHVN-'
-    o dna_alphabet -- Same as nucleic_alphabet, with 'U' (Uracil) an 
+    o dna_alphabet -- Same as nucleic_alphabet, with 'U' (Uracil) an
         alternative for 'T' (Thymidine).
     o rna_alphabet -- Same as nucleic_alphabet, with 'T' (Thymidine) an
         alternative for 'U' (Uracil).
     o reduced_nucleic_alphabet -- All ambiguous codes in 'nucleic_alphabet' are
         alternative to 'N' (aNy)
-    o reduced_protein_alphabet -- All ambiguous ('BZJ') and non-canonical amino 
-        acids codes ( 'U', Selenocysteine and 'O', Pyrrolysine)  in 
+    o reduced_protein_alphabet -- All ambiguous ('BZJ') and non-canonical amino
+        acids codes ( 'U', Selenocysteine and 'O', Pyrrolysine)  in
         'protein_alphabet' are alternative to 'X'.
     o unambiguous_dna_alphabet -- 'ACGT'
     o unambiguous_rna_alphabet -- 'ACGU'
-    o unambiguous_protein_alphabet -- The twenty canonical amino acid one letter
-        codes, in alphabetic order, 'ACDEFGHIKLMNPQRSTVWY'
+    o unambiguous_protein_alphabet -- The twenty canonical amino acid
+        one letter codes, in alphabetic order, 'ACDEFGHIKLMNPQRSTVWY'
 
 Amino Acid Codes:
     Code  Alt.  Meaning
@@ -66,12 +65,12 @@ Amino Acid Codes:
     G           Glycine
     H           Histidine
     I           Isoleucine
-    J           Leucine or Isoleucine    
+    J           Leucine or Isoleucine
     K           Lysine
     L           Leucine
     M           Methionine
     N           Asparagine
-    O           Pyrrolysine    
+    O           Pyrrolysine
     P           Proline
     Q           Glutamine
     R           Arginine
@@ -84,7 +83,7 @@ Amino Acid Codes:
     Z           Glutamate or Glutamine
     X    ?      any
     *           translation stop
-    -    .~     gap 
+    -    .~     gap
 
 Nucleotide Codes:
     Code  Alt.  Meaning
@@ -105,31 +104,29 @@ Nucleotide Codes:
     H           A C T (not G) (H comes after G)
     V           G C A (not T, not U) (V comes after U)
     N   X?      A G C T (aNy)
-    -   .~      A gap 
-    
+    -   .~      A gap
+
 
 
 
 Refs:
     http://www.chem.qmw.ac.uk/iupac/AminoAcid/A2021.html
-    http://www.chem.qmw.ac.uk/iubmb/misc/naseq.html    
+    http://www.chem.qmw.ac.uk/iubmb/misc/naseq.html
 Status:
-    Beta    
+    Beta
 Authors:
     GEC 2004,2005
 """
 from __future__ import absolute_import, division
 
 # TODO: Add this to docstring somewhere.
-# To replace all ambiguous nucleic code by 'N', replace alphabet and then n 
+# To replace all ambiguous nucleic code by 'N', replace alphabet and then n
 # normalize.
-# 
+#
 # >>> Seq( 'ACGT-RYKM', reduced_nucleic_alphabet).normalized()
 # 'ACGT-NNNN'
 
 from array import array
-
-from .moremath import argmax, sqrt
 
 from ._py3k import maketrans, _as_bytes
 
@@ -158,29 +155,32 @@ class Alphabet(object):
 
     Status:
         Beta
-    Authors: 
+    Authors:
         - GEC 2005
     """
     __slots__ = ['_letters', '_alternatives', '_ord_table', '_chr_table']
 
+    _OVERRIDE_ALPH_GUESS_PARAM = 'actual'
+
     # We're immutable, so use __new__ not __init__
     def __new__(cls, letters, alternatives=None):
         """Create a new, immutable Alphabet.
-        
+
         arguments:
         - letters -- the letters in the alphabet. The ordering determines
             the ordinal position of each character in this alphabet.
         - alt -- A list of (alternative, canonical) letters. The alternatives
-            are given the same ordinal position as the canonical characters. 
-            e.g. (('?','X'),('x', 'X')) states that '?' and 'x' are synonomous 
-            with 'X'.  Values that are not in 'letters' are ignored. Alternatives
-            that are already in 'letters' are also ignored. If the same
-            alternative character is used twice then the alternative is assigned
-            to the canonical character that occurs first in 'letters'. The 
-            default is to assume that upper and lower case characters are
-            equivalent, unless both cases are included in 'letters'.                   
+            are given the same ordinal position as the canonical characters.
+            e.g. (('?','X'),('x', 'X')) states that '?' and 'x' are synonomous
+            with 'X'.  Values that are not in 'letters' are ignored.
+            Alternatives that are already in 'letters' are also ignored.
+            If the same alternative character is used twice then the
+            alternative is assigned to the canonical character that
+            occurs first in 'letters'. The default is to assume that upper
+            and lower case characters are equivalent, unless both cases are
+            included in 'letters'.
         raises:
-            ValueError : Repetitive or otherwise illegal set of letters.        
+            ValueError : Repetitive or otherwise illegal set of letters.
         """
         self = object.__new__(cls)
 
@@ -197,10 +197,10 @@ class Alphabet(object):
         if alternatives is None:
             alternatives = equivalent_by_case
 
-        # The ord_table maps between the ordinal position of a character in ascii
-        # and the ordinal position in this alphabet. Characters not in the
-        # alphabet are given a position of 255. The ord_table is stored as a 
-        # string. 
+        # The ord_table maps between the ordinal position of a character in
+        # ascii and the ordinal position in this alphabet. Characters not in
+        # the alphabet are given a position of 255. The ord_table is stored as
+        # a string.
         ord_table = bytearray([0xff, ] * 256)
         for i, a in enumerate(letters):
             n = ord(a)
@@ -235,6 +235,31 @@ class Alphabet(object):
 
         return self
 
+    @classmethod
+    def infer_alphabet(cls, alphabet, defacto_alphabet):
+        if alphabet == cls._OVERRIDE_ALPH_GUESS_PARAM:
+            return Alphabet(defacto_alphabet)
+
+        if alphabet:
+            alphabet = Alphabet(alphabet)
+
+            if not defacto_alphabet.alphabetic(alphabet):
+                raise ValueError("The alphabet used within the PWM "
+                                 "({}) must be a subset of that provided "
+                                 "({})".format(defacto_alphabet, alphabet))
+
+            return alphabet
+        else:
+            alphabets = (unambiguous_rna_alphabet,
+                         unambiguous_dna_alphabet,
+                         unambiguous_protein_alphabet)
+
+            for alphabet in alphabets:
+                if defacto_alphabet.alphabetic(alphabet):
+                    return alphabet
+
+            return Alphabet(defacto_alphabet)
+
     def alphabetic(self, string):
         """True if all characters of the string are in this alphabet."""
         table = self._ord_table
@@ -267,7 +292,7 @@ class Alphabet(object):
         return a
 
     def normalize(self, string):
-        """Normalize an alphabetic string by converting all alternative symbols 
+        """Normalize an alphabetic string by converting all alternative symbols
         to the canonical equivalent in 'letters'.
         """
         if not self.alphabetic(string):
@@ -287,7 +312,8 @@ class Alphabet(object):
         return ''.join(let)
 
     def __repr__(self):
-        return "Alphabet( '" + self._letters + "', zip" + repr(self._alternatives) + " )"
+        return "Alphabet( '{}', zip{})".format(self._letters,
+                                               repr(self._alternatives))
 
     def __str__(self):
         return str(self._letters)
@@ -315,12 +341,12 @@ class Alphabet(object):
     @staticmethod
     def which(seqs, alphabets=None):
         """ Returns the most appropriate unambiguous protein, RNA or DNA alphabet
-        for a Seq or SeqList. If a list of alphabets is supplied, then the best alphabet
-        is selected from that list.
+        for a Seq or SeqList. If a list of alphabets is supplied,
+        then the best alphabet is selected from that list.
 
-        The heuristic is to count the occurrences of letters for each alphabet and 
-        downweight longer alphabets by the log of the alphabet length. Ties
-        go to the first alphabet in the list.
+        The heuristic is to count the occurrences of letters for each alphabet
+        and downweight longer alphabets by the log of the alphabet length.
+        Ties go to the first alphabet in the list.
 
         """
         if alphabets is None:
@@ -385,8 +411,8 @@ class Seq(str):
     Attributes:
         alphabet    -- A string or Alphabet of allowed characters.
         name        -- A short string used to identify the sequence.
-        description -- A string describing the sequence   
-        
+        description -- A string describing the sequence
+
     Authors :
         GEC 2005
     """
@@ -404,7 +430,8 @@ class Seq(str):
         if not isinstance(alphabet, Alphabet):
             alphabet = Alphabet(alphabet)
         if not alphabet.alphabetic(self):
-            raise ValueError("Sequence not alphabetic %s, '%s'" % (alphabet, self))
+            raise ValueError("Sequence not alphabetic {}, "
+                             "'{}'".format(alphabet, self))
 
         self._alphabet = alphabet
         self.name = name
@@ -414,23 +441,22 @@ class Seq(str):
 
     # BEGIN PROPERTIES
 
-    # Make alphabet constant 
+    # Make alphabet constant
     @property
     def alphabet(self):
         return self._alphabet
 
-    # END PROPERTIES        
-
+    # END PROPERTIES
 
     def ords(self):
-        """ Convert sequence to an array of integers 
-        in the range [0, len(alphabet) ) 
+        """ Convert sequence to an array of integers
+        in the range [0, len(alphabet) )
         """
         return self.alphabet.ords(self)
 
     def tally(self, alphabet=None):
         """Counts the occurrences of alphabetic characters.
-                
+
         Arguments:
         - alphabet -- an optional alternative alphabet
 
@@ -484,15 +510,15 @@ class Seq(str):
         return not self.__eq__(other)
 
     def tostring(self):
-        """ Converts Seq to a raw string. 
+        """ Converts Seq to a raw string.
         """
         # Compatibility with biopython
         return str(self)
 
     # ---- Transformations of Seq ----
     def reverse(self):
-        """Return the reversed sequence. 
-        
+        """Return the reversed sequence.
+
         Note that this method returns a new object, in contrast to
         the in-place reverse() method of list objects.
         """
@@ -515,13 +541,15 @@ class Seq(str):
     def lower(self):
         """Return a lower case copy of the sequence. """
         cls = self.__class__
-        trans = maketrans('ABCDEFGHIJKLMNOPQRSTUVWXYZ', 'abcdefghijklmnopqrstuvwxyz')
+        trans = maketrans('ABCDEFGHIJKLMNOPQRSTUVWXYZ',
+                          'abcdefghijklmnopqrstuvwxyz')
         return cls(str(self).translate(trans), self.alphabet)
 
     def upper(self):
         """Return a lower case copy of the sequence. """
         cls = self.__class__
-        trans = maketrans('abcdefghijklmnopqrstuvwxyz', 'ABCDEFGHIJKLMNOPQRSTUVWXYZ')
+        trans = maketrans('abcdefghijklmnopqrstuvwxyz',
+                          'ABCDEFGHIJKLMNOPQRSTUVWXYZ')
         return cls(str(self).translate(trans), self.alphabet)
 
     def mask(self, letters='abcdefghijklmnopqrstuvwxyz', mask='X'):
@@ -556,7 +584,7 @@ class Seq(str):
 
     def reverse_complement(self):
         """Returns reversed complementary nucleic acid sequence (i.e. the other
-        strand of a DNA sequence.) 
+        strand of a DNA sequence.)
         """
         return self.reverse().complement()
 
@@ -569,9 +597,10 @@ class Seq(str):
         return cls(s, self.alphabet, self.name, self.description)
 
     def words(self, k, alphabet=None):
-        """Return an iteration over all subwords of length k in the sequence. If an optional
-        alphabet is provided, only words from that alphabet are returned.
-        
+        """Return an iteration over all subwords of length k in the sequence.
+           If an optional alphabet is provided, only words from that
+           alphabet are returned.
+
         >>> list(Seq("abcabc").words(3))
         ['abc', 'bca', 'cab', 'abc']
         """
@@ -590,7 +619,7 @@ class Seq(str):
 
     def word_count(self, k, alphabet=None):
         """Return a count of all subwords in the sequence.
-        
+
         >>> from corebio.seq import *
         >>> Seq("abcabc").word_count(3)
         [('abc', 2), ('bca', 1), ('cab', 1)]
@@ -604,7 +633,7 @@ class Seq(str):
 
 
 class SeqList(list):
-    """ A list of sequences. 
+    """ A list of sequences.
     """
 
     __slots__ = ["alphabet", "name", "description"]
@@ -682,7 +711,8 @@ class SeqList(list):
 
         for o in ords:
             if len(o) != L:
-                raise ValueError("Sequences are of incommensurate lengths. Cannot tally.")
+                raise ValueError("Sequences are of incommensurate lengths. "
+                                 "Cannot tally.")
             for j, n in enumerate(o):
                 if n < N:
                     counts[j][n] += 1
@@ -695,18 +725,18 @@ class SeqList(list):
 
 
 def dna(string):
-    """Create an alphabetic sequence representing a stretch of DNA.    
+    """Create an alphabetic sequence representing a stretch of DNA.
     """
     return Seq(string, alphabet=dna_alphabet)
 
 
 def rna(string):
-    """Create an alphabetic sequence representing a stretch of RNA.    
+    """Create an alphabetic sequence representing a stretch of RNA.
     """
     return Seq(string, alphabet=rna_alphabet)
 
 
 def protein(string):
-    """Create an alphabetic sequence representing a stretch of polypeptide.    
+    """Create an alphabetic sequence representing a stretch of polypeptide.
     """
     return Seq(string, alphabet=protein_alphabet)

--- a/weblogolib/__init__.py
+++ b/weblogolib/__init__.py
@@ -4,44 +4,44 @@
 
 #  Copyright (c) 2003-2004 The Regents of the University of California.
 #  Copyright (c) 2005 Gavin E. Crooks
-#  Copyright (c) 2006-2015, The Regents of the University of California, through 
-#  Lawrence Berkeley National Laboratory (subject to receipt of any required
-#  approvals from the U.S. Dept. of Energy).  All rights reserved.
+#  Copyright (c) 2006-2015, The Regents of the University of California,
+#  through Lawrence Berkeley National Laboratory (subject to receipt of any
+#  required approvals from the U.S. Dept. of Energy).  All rights reserved.
 
 #  This software is distributed under the new BSD Open Source License.
 #  <http://www.opensource.org/licenses/bsd-license.html>
 #
-#  Redistribution and use in source and binary forms, with or without 
-#  modification, are permitted provided that the following conditions are met: 
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are met:
 #
-#  (1) Redistributions of source code must retain the above copyright notice, 
-#  this list of conditions and the following disclaimer. 
+#  (1) Redistributions of source code must retain the above copyright notice,
+#  this list of conditions and the following disclaimer.
 #
-#  (2) Redistributions in binary form must reproduce the above copyright 
-#  notice, this list of conditions and the following disclaimer in the 
-#  documentation and or other materials provided with the distribution. 
+#  (2) Redistributions in binary form must reproduce the above copyright
+#  notice, this list of conditions and the following disclaimer in the
+#  documentation and or other materials provided with the distribution.
 #
-#  (3) Neither the name of the University of California, Lawrence Berkeley 
-#  National Laboratory, U.S. Dept. of Energy nor the names of its contributors 
-#  may be used to endorse or promote products derived from this software 
-#  without specific prior written permission. 
+#  (3) Neither the name of the University of California, Lawrence Berkeley
+#  National Laboratory, U.S. Dept. of Energy nor the names of its contributors
+#  may be used to endorse or promote products derived from this software
+#  without specific prior written permission.
 #
-#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" 
-#  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE 
-#  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE 
-#  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE 
-#  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR 
-#  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF 
-#  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
-#  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN 
-#  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
-#  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE 
-#  POSSIBILITY OF SUCH DAMAGE. 
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+#  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+#  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+#  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+#  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+#  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+#  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+#  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+#  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+#  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+#  POSSIBILITY OF SUCH DAMAGE.
 
 # Replicates README.txt
 
 """
-WebLogo (https://github.com/WebLogo/weblogo) is a tool for creating sequence 
+WebLogo (https://github.com/WebLogo/weblogo) is a tool for creating sequence
 logos from biological sequence alignments.  It can be run on the command line,
 as a standalone webserver, as a CGI webapp, or as a python library.
 
@@ -57,49 +57,48 @@ For help on the command line interface run
 
 To build a simple logo run
     ./weblogo  < cap.fa > logo0.eps
-    
-To run as a standalone webserver at localhost:8080 
+
+To run as a standalone webserver at localhost:8080
     ./weblogo --serve
 
 To create a logo in python code:
     >>> from weblogolib import *
     >>> fin = open('cap.fa')
-    >>> seqs = read_seq_data(fin) 
+    >>> seqs = read_seq_data(fin)
     >>> data = LogoData.from_seqs(seqs)
     >>> options = LogoOptions()
     >>> options.title = "A Logo Title"
     >>> format = LogoFormat(data, options)
     >>> eps = eps_formatter( data, format)
-   
+
 
 
 -- Distribution and Modification --
-This package is distributed under the new BSD Open Source License. 
+This package is distributed under the new BSD Open Source License.
 Please see the LICENSE.txt file for details on copyright and licensing.
-The WebLogo source code can be downloaded from 
+The WebLogo source code can be downloaded from
 https://github.com/WebLogo/weblogo
 
 WebLogo requires Python 2.6, 2.7, 3.2, 3.3 & 3.4 and the python
 array package 'numpy' (http://www.scipy.org/Download)
 
 Generating logos in PDF or bitmap graphics formats require that the ghostscript
-program 'gs' be installed. Scalable Vector Graphics (SVG) format also requires 
+program 'gs' be installed. Scalable Vector Graphics (SVG) format also requires
 the program 'pdf2svg'.
 
 """
 from __future__ import absolute_import, division, print_function
 
-import copy
 import os
 import sys
 
 from datetime import datetime
-from math import exp, log, sqrt
+from math import log, sqrt
 from string import Template
-from subprocess import *
+from subprocess import Popen, PIPE
 
 # Avoid 'from numpy import *' since numpy has lots of names defined
-from numpy import array, asarray, float64, ones, zeros, any, int32, all, shape
+from numpy import array, asarray, float64, ones, zeros, any
 import numpy as na
 
 from .color import *
@@ -108,11 +107,12 @@ from .logomath import Dirichlet
 
 import corebio
 from corebio import seq_io
-from corebio.data import (amino_acid_composition, amino_acid_letters, dna_letters, rna_letters)
-from corebio.moremath import *
-from corebio.seq import (Alphabet, Seq, SeqList, unambiguous_dna_alphabet,
-                         unambiguous_rna_alphabet, unambiguous_protein_alphabet)
-from corebio.utils import (isfloat, find_command, ArgumentError, stdrepr, resource_string, resource_filename)
+from corebio.data import amino_acid_composition
+from corebio.seq import (Alphabet, unambiguous_dna_alphabet,
+                         unambiguous_rna_alphabet,
+                         unambiguous_protein_alphabet)
+from corebio.utils import (isfloat, find_command, ArgumentError,
+                           stdrepr, resource_string)
 
 from corebio._py3k import StringIO, urlopen, urlparse, urlunparse, Request
 
@@ -282,7 +282,7 @@ std_units = {
     "probability": None,
 }
 
-# The base stack width is set equal to 9pt Courier. 
+# The base stack width is set equal to 9pt Courier.
 # (Courier has a width equal to 3/5 of the point size.)
 # Check that can get 80 characters in journal page @small
 # 40 characters in a journal column
@@ -309,47 +309,47 @@ std_percentCG = {
 
 
 # Thermus thermophilus: Henne A, Bruggemann H, Raasch C, Wiezer A, Hartsch T,
-# Liesegang H, Johann A, Lienard T, Gohl O, Martinez-Arias R, Jacobi C, 
-# Starkuviene V, Schlenczeck S, Dencker S, Huber R, Klenk HP, Kramer W, 
-# Merkl R, Gottschalk G, Fritz HJ: The genome sequence of the extreme 
+# Liesegang H, Johann A, Lienard T, Gohl O, Martinez-Arias R, Jacobi C,
+# Starkuviene V, Schlenczeck S, Dencker S, Huber R, Klenk HP, Kramer W,
+# Merkl R, Gottschalk G, Fritz HJ: The genome sequence of the extreme
 # thermophile Thermus thermophilus.
 # Nat Biotechnol 2004, 22:547-53
 
 
 class LogoOptions(object):
     """ A container for all logo formatting options. Not all of these
-    are directly accessible through the CLI or web interfaces. 
-    
+    are directly accessible through the CLI or web interfaces.
+
     To display LogoOption defaults:
     >>> from weblogolib import *
     >>> LogoOptions()
-    
+
     All physical lengths are measured in points. (72 points per inch, 28.3 points per cm)
-      
+
     String attributes:
         o creator_text             -- Embedded as comment in figures.
-        o logo_title               -- Creates title for the sequence logo     
+        o logo_title               -- Creates title for the sequence logo
         o logo_label               -- An optional figure label, added to the top left (e.g. '(a)').
-        o unit_name                -- See std_units for options. (Default 'bits') 
-        o yaxis_label              -- Defaults to unit_name      
+        o unit_name                -- See std_units for options. (Default 'bits')
+        o yaxis_label              -- Defaults to unit_name
         o xaxis_label              -- Add a label to the x-axis, or hide x-axis altogether.
         o fineprint                -- Defaults to WebLogo name and version
-        
+
     Boolean attributes:
         o show_yaxis               -- Display entropy scale along y-axis (default: True)
-        o show_xaxis               -- Display sequence numbers along x-axis (default: True)                                                
+        o show_xaxis               -- Display sequence numbers along x-axis (default: True)
         o show_ends                -- Display label at the ends of the sequence (default: False)
-        o show_fineprint           -- Toggle display of the WebLogo version information in the lower right corner. Optional, but we appreciate the acknowledgment. 
+        o show_fineprint           -- Toggle display of the WebLogo version information in the lower right corner. Optional, but we appreciate the acknowledgment.
         o show_errorbars           -- Draw errorbars (default: False)
         o show_boxes               -- Draw boxes around stack characters (default: True)
-        o debug                    -- Draw extra graphics debugging information. 
-        o rotate_numbers           -- Draw xaxis numbers with vertical orientation? 
+        o debug                    -- Draw extra graphics debugging information.
+        o rotate_numbers           -- Draw xaxis numbers with vertical orientation?
         o scale_width              -- boolean, scale width of characters proportional to ungaps
-        o pad_right                -- Make a single line logo the same width as multiline logos (default: False)                           
-                                
+        o pad_right                -- Make a single line logo the same width as multiline logos (default: False)
+
     Other attributes:
         o stacks_per_line           -- Maximum number of logo stacks per logo line. (Default: 40)
-        o yaxis_tic_interval        -- Distance between ticmarks on y-axis(default: 1.0) 
+        o yaxis_tic_interval        -- Distance between ticmarks on y-axis(default: 1.0)
         o yaxis_minor_tic_ratio     -- Distance between minor tic ratio
         o yaxis_scale               -- Sets height of the y-axis in designated units
         o xaxis_tic_interval        -- Distance between ticmarks on x-axis(default: 1.0)
@@ -362,11 +362,11 @@ class LogoOptions(object):
         o errorbar_gray             -- Sets error bars' gray scale percentage (default .75)
 
         o resolution                -- Dots per inch (default: 96). Used for bitmapped output formats
-        
+
         o default_color             -- Symbol color if not otherwise specified
-        o color_scheme              -- A custom color scheme can be specified using CSS2 (Cascading Style Sheet) syntax. 
-                                    (E.g. 'red', '#F00', '#FF0000', 'rgb(255, 0, 0)', 'rgb(100%, 0%, 0%)' or 'hsl(0, 100%, 50%)' for the color red.) 
-        
+        o color_scheme              -- A custom color scheme can be specified using CSS2 (Cascading Style Sheet) syntax.
+                                    (E.g. 'red', '#F00', '#FF0000', 'rgb(255, 0, 0)', 'rgb(100%, 0%, 0%)' or 'hsl(0, 100%, 50%)' for the color red.)
+
         o stack_width               -- Scale the visible stack width by the fraction of symbols in the column (I.e. columns with
                                         many gaps of unknowns are narrow.)  (Default: yes)
         o stack_aspect_ratio        -- Ratio of stack height to width (default: 5)
@@ -375,16 +375,16 @@ class LogoOptions(object):
         o stroke_width              -- Default: 0.5 pts
         o tic_length                -- Default: 5 pts
         o stack_margin              -- Default: 0.5 pts
-        
+
         o small_fontsize            -- Small text font size in points
         o fontsize                  -- Regular text font size in points
         o title_fontsize            -- Title text font size in points
         o number_fontsize           -- Font size for axis-numbers, in points.
-        
+
         o text_font                 -- Select font for labels
         o logo_font                 -- Select font for Logo
         o title_font                -- Select font for Logo's title
-        
+
         o first_index               -- Index of first position in sequence data
         o logo_start                -- Lower bound of sequence to display
         o logo_end                  -- Upper bound of sequence to display
@@ -393,7 +393,7 @@ class LogoOptions(object):
 
     def __init__(self, **kwargs):
         """ Create a new LogoOptions instance.
-        
+
         >>> L = LogoOptions(logo_title = "Some Title String")
         >>> L.show_yaxis = False
         >>> repr(L)
@@ -486,20 +486,20 @@ class LogoOptions(object):
 
 
 class LogoFormat(LogoOptions):
-    """ Specifies the format of the logo. Requires LogoData and LogoOptions 
+    """ Specifies the format of the logo. Requires LogoData and LogoOptions
     objects.
-    
+
     >>> data = LogoData.from_seqs(seqs )
     >>> options = LogoOptions()
     >>> options.title = "A Logo Title"
-    >>> format = LogoFormat(data, options) 
-    
+    >>> format = LogoFormat(data, options)
+
     Raises an ArgumentError if arguments are invalid.
     """
 
     def __init__(self, data, options=None):
         """ Create a new LogoFormat instance.
-        
+
         """
         LogoOptions.__init__(self)
 
@@ -551,15 +551,15 @@ class LogoFormat(LogoOptions):
             ("tic_length", lambda x: x > 0.0, "Invalid tic length."),
         )
 
-        # Run arguments tests. The second, attribute argument to the ArgumentError is 
+        # Run arguments tests. The second, attribute argument to the ArgumentError is
         # used by the UI to provide user feedback.
-        # FIXME: More validation        
+        # FIXME: More validation
         for test in arg_conditions:
             if not test[1](getattr(self, test[0])):
                 raise ArgumentError(test[2], test[0])
 
         # Inclusive upper and lower bounds
-        # FIXME: Validate here. Move from eps_formatter        
+        # FIXME: Validate here. Move from eps_formatter
         if self.logo_start is None:
             self.logo_start = self.first_index
 
@@ -701,7 +701,7 @@ class LogoFormat(LogoOptions):
 # that draws a representation of the logo.
 # The main graphical formatter is eps_formatter. A mapping 'formatters'
 # containing all available formatters is located after the formatter
-# definitions. 
+# definitions.
 # Each formatter returns binary data. The eps and data formats can decoded
 # to strings, e.g. eps_as_string = eps_data.decode()
 
@@ -772,7 +772,7 @@ def png_print_formatter(data, format):
 
 
 def txt_formatter(logodata, format):
-    """ Create a text representation of the logo data. 
+    """ Create a text representation of the logo data.
     """
     return str(logodata).encode()
 
@@ -895,7 +895,7 @@ def eps_formatter(logodata, format):
 
 
 
-# map between output format names and logo  
+# map between output format names and logo
 formatters = {
     'eps': eps_formatter,
     'pdf': pdf_formatter,
@@ -911,9 +911,9 @@ default_formatter = eps_formatter
 
 def parse_prior(composition, alphabet, weight=None):
     """ Parse a description of the expected monomer distribution of a sequence.
-    
+
     Valid compositions:
-    
+
     - None or 'none' :        No composition sepecified
     - 'auto' or 'automatic' : Use the typical average distribution
                               for proteins and an equiprobable distribution for
@@ -1031,8 +1031,8 @@ def read_seq_data(fin,
                   alphabet=None,
                   ignore_lower_case=False,
                   max_file_size=0):
-    """ Read sequence data from the input stream and return a seqs object. 
-    
+    """ Read sequence data from the input stream and return a seqs object.
+
     The environment variable WEBLOGO_MAX_FILE_SIZE overides the max_file_size argument.
     Used to limit the load on the WebLogo webserver.
     """
@@ -1040,7 +1040,7 @@ def read_seq_data(fin,
     max_file_size = int(os.environ.get("WEBLOGO_MAX_FILE_SIZE", max_file_size))
 
     # If max_file_size is set, or if fin==stdin (which is non-seekable), we
-    # read the data and replace fin with a StringIO object. 
+    # read the data and replace fin with a StringIO object.
     if (max_file_size > 0):
         data = fin.read(max_file_size)
         more_data = fin.read(2)
@@ -1071,10 +1071,11 @@ def read_seq_data(fin,
 
 class LogoData(object):
     """The data needed to generate a sequence logo.
-       
-    - alphabet --  The set of symbols to count. 
+
+    - alphabet --  The set of symbols to count.
                    See also --sequence-type, --ignore-lower-case
-    - length  --   All sequences must be the same length, else WebLogo will return an error
+    - length  --   All sequences must be the same length,
+                       else WebLogo will return an error
     - counts  --   An array of character counts
     - entropy --   The relative entropy of each column
     - entropy_interval -- entropy confidence interval
@@ -1196,7 +1197,8 @@ class LogoData(object):
 
 def _from_URL_fileopen(target_url):
     """opens files from a remote URL location"""
-    import shutil, tempfile
+    import shutil
+    import tempfile
 
     # parsing url in component parts
     (scheme, net_location, path, param, query, frag) = urlparse(target_url)

--- a/weblogolib/_cli.py
+++ b/weblogolib/_cli.py
@@ -380,6 +380,7 @@ def _build_option_parser():
                         action="store",
                         help="The set of symbols to count, e.g. 'AGTC'. "
                              "All characters not in the alphabet are ignored. "
+                             "'actual' can be specified to use an alphabet derived from the symbols present in the input data. "
                              "If neither the alphabet nor sequence-type are specified then weblogo will examine the input data and make an educated guess. "
                              "See also --sequence-type, --ignore-lower-case")
 


### PR DESCRIPTION
Allowed TRANSFAC PWMs containing any subset of a provided alphabet to be validly parsed.

- modified alphabet verification to check that the *de facto* alphabet is a subset of that provided
- refactored, to not attempt to reindex the PWM to any other non–*de facto* alphabet

It is not clear what the correct form of reindexing ought be in such contexts. Accordingly, we simply use the *de facto* alphabet, provided that it is not a superset of a user-defined alphabet.

Custom PWM alphabets can now be automatically parsed, without the specification of an `--alphabet` parameter, but `--color` parameters should still be provided, when colouring of custom alphabets is desired.