### PR TITLE
Center logo when "--show-yaxis no" (issue #74).

### DIFF
--- a/weblogolib/__init__.py
+++ b/weblogolib/__init__.py
@@ -626,12 +626,15 @@ class LogoFormat(LogoOptions):
         if self.show_yaxis:
             self.line_margin_left = self.fontsize * 3.0
         else:
-            self.line_margin_left = 0
+            if self.show_ends and self.show_xaxis:
+                self.line_margin_left = self.fontsize * 1.5
+            else:
+                self.line_margin_left = 4
 
-        if self.show_ends:
+        if self.show_ends and self.show_xaxis:
             self.line_margin_right = self.fontsize * 1.5
         else:
-            self.line_margin_right = self.fontsize
+            self.line_margin_right = 4
 
         if self.show_xaxis:
             if self.rotate_numbers:


### PR DESCRIPTION
Before this patch, there was no margin at the left side of the
logo when "--show-yaxis no", while at the right side of the logo
a big margin was shown. After this patch, the same margin is
applied at both sides, when "--show-yaxis no".