### PR TITLE
Import version from corebio instead. Fixes #76

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ from setuptools import setup, find_packages
 #warnings.simplefilter('ignore', UserWarning, lineno=236)
 
 
-from weblogolib import __version__
+from corebio import __version__
 
 
 def main():


### PR DESCRIPTION
The `corebio` import works even when none of the requirements have been installed yet.