### PR TITLE
setuptools_scm is not needed for install, only setup

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ setup(
     name="weblogo",
     python_requires='>=3.6',
 
-    install_requires=['numpy', 'scipy', 'setuptools', 'setuptools_scm'],
+    install_requires=['numpy', 'scipy', 'setuptools'],
 
     use_scm_version=True,
     setup_requires=['setuptools_scm'],


### PR DESCRIPTION
setuptools_scm is an especially nasty package to have installed because it non-transparently hooks into the standard setuptools package and changes its behavior. Depending on the setuptools_scm version this may lead to really hard-to-debug situations when installing other packages.